### PR TITLE
Resolve default value expressions for negative numbers, fail in CI on linting & unit-testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,13 +36,11 @@ steps:
     rush flow
   displayName: "Type check"
   workingDirectory: webdoc
-  continueOnError: true
 
 - script: |
     rush lint
   displayName: "Lint"
   workingDirectory: webdoc
-  continueOnError: true
 
 - script: |
     rush unit-test

--- a/packages/webdoc-default-template/helper/renderer-plugins/signature.js
+++ b/packages/webdoc-default-template/helper/renderer-plugins/signature.js
@@ -62,6 +62,9 @@ exports.signaturePlugin = {
       if (!options.noTail && doc.dataType) {
         signature += ": " + linker.linkTo(doc.dataType, undefined, {htmlSafe: false});
       }
+      if (doc.defaultValue) {
+        signature += " = " + doc.defaultValue;
+      }
       break;
     case "ClassDoc":
       if (doc.extends) {

--- a/packages/webdoc-parser/src/symbols-babel/extract-symbol.js
+++ b/packages/webdoc-parser/src/symbols-babel/extract-symbol.js
@@ -406,7 +406,7 @@ function resolveRootObject(expression: MemberExpression): string {
 
 // Used to get default value
 // TODO: Resolve a lot more expressions
-function resolveExpression(expression: BabelNodeExpression): string | undefined {
+function resolveExpression(expression: BabelNodeExpression): string | void {
   if (isLiteral(expression)) {
     if (isStringLiteral(expression)) {
       return `"${expression.value}"`;
@@ -415,7 +415,7 @@ function resolveExpression(expression: BabelNodeExpression): string | undefined 
     }
   }
   if (isUnaryExpression(expression)) {
-    return `-${resolveExpression(expression.argument)}`;
+    return `-${resolveExpression(expression.argument) || ""}`;
   }
 }
 

--- a/packages/webdoc-parser/test/lang-ts.js
+++ b/packages/webdoc-parser/test/lang-ts.js
@@ -8,7 +8,7 @@ describe("@webdoc/parser.LanguageIntegration{@lang ts}", function() {
   it("should parse classes correctly", function() {
     let symtree = buildSymbolTree(`
       class ClassName {
-        private readonly initProperty: number = 11;
+        private readonly initProperty: number = -11;
 
         constructor() {
           /**
@@ -47,7 +47,7 @@ describe("@webdoc/parser.LanguageIntegration{@lang ts}", function() {
     expect(symbolInitProperty.meta.dataType).to.not.equal(undefined);
     expect(symbolInitProperty.meta.dataType[0]).to.equal("number");
     expect(symbolInitProperty.meta.access).to.equal("private");
-    expect(symbolInitProperty.meta.defaultValue).to.equal("11");
+    expect(symbolInitProperty.meta.defaultValue).to.equal("-11");
     expect(symbolInitProperty.comment).to.not.equal("");
     expect(symbolInitProperty.meta.readonly).to.equal(true);
   });


### PR DESCRIPTION
Fixes #79 

Edited the CI so failures prevent the PR from getting merged. This is b/c we don't have any linting or type checking errors on master.