### PR TITLE
Provide siteDomain and siteRoot fallback

### DIFF
--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -165,7 +165,7 @@ function LinkerPluginShell() {
       
       // Provide fallback if URL
       if (siteDomain === undefined && isURL) {
-        const { origin, pathname } = new URL(uri);
+        const {origin, pathname} = new URL(uri);
 
         siteDomain = origin;
         siteRoot = path.dirname(pathname);

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -3,6 +3,7 @@ import * as external from "@webdoc/externalize";
 import type {Doc, DocType} from "@webdoc/types";
 import fetch from "node-fetch";
 import {promises as fs} from "fs";
+import * as path from "path";
 import {isDataType} from "@webdoc/model";
 import {templateLogger} from "../Logger";
 
@@ -160,7 +161,15 @@ function LinkerPluginShell() {
 
       const manifest = external.read(contents);
       const {registry} = manifest;
-      const {siteDomain, siteRoot} = manifest.metadata;
+      let {siteDomain, siteRoot} = manifest.metadata;
+      
+      // Provide fallback if URL
+      if (siteDomain === undefined && isURL) {
+        const { origin, pathname } = new URL(uri);
+
+        siteDomain = origin;
+        siteRoot = path.dirname(pathname);
+      }
 
       if (!siteDomain) {
         throw new Error("Imported documented interfaces must have a siteDomain!");


### PR DESCRIPTION
For linking against another API, this change provides a way to do that even if the API being included doesn't contain a `siteDomain` in the metadata. In general, this makes linking much more flexible and portable as well as making it easier to test locally.

Use-case for this change is https://github.com/pixijs/guides which needs to link against https://pixijs.download/release/docs/pixi.api.json, but that JSON doesn't define `siteDomain` in the webdoc config.