### PR TITLE
Fix: Handle string literals being used as keys in enums …

### DIFF
--- a/packages/webdoc-parser/src/symbols-babel/extract-symbol.js
+++ b/packages/webdoc-parser/src/symbols-babel/extract-symbol.js
@@ -29,6 +29,7 @@ import {
   isObjectMethod,
   isObjectProperty,
   isReturnStatement,
+  isStringLiteral,
   isTSAsExpression,
   isTSDeclareFunction,
   isTSDeclareMethod,
@@ -39,8 +40,7 @@ import {
   isTSParameterProperty,
   isTSPropertySignature,
   isTSTypeElement,
-  isThisExpression,
-  isVariableDeclarator,
+  isThisExpression, isVariableDeclarator,
 } from "@babel/types";
 
 import {OBLIGATE_LEAF, PASS_THROUGH, type Symbol, VIRTUAL, isVirtual} from "../types/Symbol";
@@ -184,6 +184,7 @@ export default function extractSymbol(
     // let symbolName = (() => <ClassExpression> | <FunctionExpression)();
     // let symbolName = (function() { class symbolName {}; return symbolName; })();
     // propertyName:           <Literal> | <ClassExpression> | <FunctionExpression>,
+    // "propertyName":         <Literal> | <ClassExpression> | <FunctionExpression>,
 
     // NOTE: If this type of symbol is initialized to a <ClassExpression> or <FunctionExpression>,
     // it treated as a virtual symbol so that the assigned class/function (i.e. initially a child
@@ -214,7 +215,7 @@ export default function extractSymbol(
         nodeSymbol.meta.readonly = true;
       }
     } else {// ObjectProperty
-      name = node.key.name;
+      name = isStringLiteral(node.key) ? node.key.value : node.key.name;
       init = node.value;
     }
 

--- a/packages/webdoc-parser/src/transformer/symbol-to-doc.js
+++ b/packages/webdoc-parser/src/transformer/symbol-to-doc.js
@@ -115,7 +115,7 @@ const TAG_PARSERS: { [id: string]: TagParser } = {
 const TAG_OVERRIDES: { [id: string]: string | any } = { // replace any, no lazy
   "class": "ClassDoc",
   "interface": "InterfaceDoc",
-  //  "enum": "PropertyDoc",
+  "enum": "EnumDoc",
   "member": "PropertyDoc",
   "method": "MethodDoc",
   "mixin": "MixinDoc",

--- a/packages/webdoc-parser/test/parse.js
+++ b/packages/webdoc-parser/test/parse.js
@@ -185,4 +185,29 @@ describe("@webdoc/parser.parse", function() {
     expect(engineClass.description).to.include("Good evening!");
     expect(engineClass.description).to.include("Hello world!");
   });
+
+  it("should resolve objects properties using string literals as keys correctly", async function() {
+    const documentTree = await parse(`
+      /** @namespace input */
+      /**
+       * standard keyboard constants
+       * @public
+       * @enum {number}
+       * @namespace KEY
+       * @memberof input
+       */
+      const KEY = {
+          /** @memberof input.KEY */      
+          "BACKSPACE" : 8,
+          /** @memberof input.KEY */
+          "TAB" : 9,
+          /** @memberof input.KEY */
+          "ENTER" : 13,
+      };
+    `);
+
+    const docKeyEnum = findDoc("input.KEY", documentTree);
+
+    expect(docKeyEnum.members.length).to.equal(3);
+  });
 });


### PR DESCRIPTION
Fixes #162

**This PR Addresses:**  
[Object property documentation not being parsed correctly](https://github.com/webdoc-labs/webdoc/issues/162)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>