### PR TITLE
Fix: Make standalone function pages show parameters, returns tables

### DIFF
--- a/packages/webdoc-default-template/tmpl/components/members-explorer/index.tmpl
+++ b/packages/webdoc-default-template/tmpl/components/members-explorer/index.tmpl
@@ -12,6 +12,8 @@
     const doc = obj;
     const members = doc.members;
 
+    if (members.length === 0) return;
+
     const publicProperties = this.plugins.categoryFilter(doc, {
       access: "public",
       type: "PropertyDoc"

--- a/packages/webdoc-default-template/tmpl/document.tmpl
+++ b/packages/webdoc-default-template/tmpl/document.tmpl
@@ -53,9 +53,14 @@
         require,
         sources,
       }) ?>
+    <?js } else if (doc.type === "FunctionDoc") { ?>
+       <?js if (doc.params) { ?><?js= this.partial("components/member/params.tmpl", doc.params) ?><?js } ?>
+       <?js if (doc.returns) { ?><?js= this.partial("components/member/returns.tmpl", doc.returns) ?><?js } ?>
     <?js } ?>
 
-    <?js= this.partial("components/summary/index.tmpl", doc) ?>
+    <?js if (doc.members.length > 0) { ?>
+      <?js= this.partial("components/summary/index.tmpl", doc) ?>
+    <?js } ?>
 
     <?js= this.partial("components/members.tmpl", {
       title: "Public Properties",


### PR DESCRIPTION
Fixes #161

And also hide summary / right sidebar if no children to show