### PR TITLE
JavaScript method overloads not being parsed

### DIFF
--- a/packages/webdoc-parser/src/tag-parsers/parseSimple.js
+++ b/packages/webdoc-parser/src/tag-parsers/parseSimple.js
@@ -123,6 +123,7 @@ export function parseName(value: string, doc: $Shape<BaseDoc>): $Shape<NameTag> 
   return {
     alias: value,
     type: "NameTag",
+    value,
   };
 }
 

--- a/packages/webdoc-parser/src/transformer/symbol-to-doc.js
+++ b/packages/webdoc-parser/src/transformer/symbol-to-doc.js
@@ -122,6 +122,7 @@ const TAG_OVERRIDES: { [id: string]: string | any } = { // replace any, no lazy
   "typedef": "TypedefDoc",
   "namespace": "NSDoc",
   "event": "EventDoc",
+  "function": "FunctionDoc",
 };
 
 // Tags that end only when another tag is found or two lines are blank for consecutively

--- a/packages/webdoc-parser/test/parse.js
+++ b/packages/webdoc-parser/test/parse.js
@@ -210,4 +210,42 @@ describe("@webdoc/parser.parse", function() {
 
     expect(docKeyEnum.members.length).to.equal(3);
   });
+
+  it("should parse method overloads in orphan doc comments", async function() {
+    const documentTree = await parse(`
+      /** Rectangle */
+      class Rect {
+        /**
+         * Returns true if the rectangle contains the given rectangle
+         * @name contains
+         * @memberof Rect
+         * @function
+         * @param {Rect} rect
+         * @returns {boolean} true if contains
+         */
+    
+        /**
+         * Returns true if the rectangle contains the given point
+         * @name contains
+         * @memberof Rect
+         * @function
+         * @param  {number} x - x coordinate
+         * @param  {number} y - y coordinate
+         * @returns {boolean} true if contains
+         */
+    
+        /**
+         * Returns true if the rectangle contains the given point
+         * @name contains
+         * @memberof Rect
+         * @function
+         * @param {Vector2d} point
+         * @returns {boolean} true if contains
+         */
+        contains() { }
+      }
+    `);
+
+    expect(findDoc("Rect", documentTree).members.length).to.equal(4);
+  });
 });


### PR DESCRIPTION
Fixes #163

**This PR Addresses:**  
[JavaScript method overloads not being parsed](https://github.com/webdoc-labs/webdoc/issues/163)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>