### PR TITLE
Feature: Add highlighted source code from examples in documentation comments …

### DIFF
--- a/packages/webdoc-default-template/publish.js
+++ b/packages/webdoc-default-template/publish.js
@@ -122,6 +122,7 @@ exports.publish = async function publish(options /*: PublishOptions */) {
     .installPlugin("signature", signaturePlugin)
     .installPlugin("categoryFilter", categoryFilterPlugin)
     .installPlugin("relations", RelationsPlugin)
+    .installPlugin("hljs", hljs)
     .setGlobalTemplateData({
       appBar: {
         items: appBarItems,

--- a/packages/webdoc-default-template/tmpl/components/content/example.tmpl
+++ b/packages/webdoc-default-template/tmpl/components/content/example.tmpl
@@ -1,0 +1,8 @@
+<?js
+  let code = obj;
+
+  if (this.plugins.hljs) {
+    code = this.plugins.hljs.highlightAuto(code).value;
+  }
+?>
+<pre><code><?js= code ?></code></pre>

--- a/packages/webdoc-default-template/tmpl/components/member/index.tmpl
+++ b/packages/webdoc-default-template/tmpl/components/member/index.tmpl
@@ -13,6 +13,7 @@ const sourceName = source && require("path").basename(doc.loc.file.path);
 const sourceStart = source && doc.loc.start ? ":" + doc.loc.start.line : "";
 const sourceLinkFragment = source && doc.loc.start ? "#" + doc.loc.start.line : "";
 const properties = doc.members.filter(child => child.type === "PropertyDoc");
+const examples = doc.examples ? doc.examples : [];
 
 const modifiers = [
   doc.deprecated ? "member__title_deprecated" : ""
@@ -54,6 +55,10 @@ const modifiers = [
 
   <div class="member__brief"><?js= doc.brief ?></div>
   <div class="member__description"><?js= doc.description ?></div>
+
+  <?js for (const example of examples) { ?>
+    <?js= this.partial("components/content/example.tmpl", example.code) ?>
+  <?js } ?>
 
   <?js if (properties.length) { ?>
     <?js= this.partial("components/member/properties.tmpl", properties) ?>

--- a/packages/webdoc-default-template/tmpl/document.tmpl
+++ b/packages/webdoc-default-template/tmpl/document.tmpl
@@ -41,6 +41,10 @@
     <div class="document__brief"><?js= doc.brief ?></div>
     <div class="document__description"><?js= doc.description ?></div>
 
+    <?js for (const example of doc.examples ?? []) { ?>
+      <?js= this.partial("components/content/example.tmpl", example.code) ?>
+    <?js } ?>
+
     <?js= this.partial("components/member/see.tmpl", doc.see) ?>
 
     <?js if (doc.type === "ClassDoc") { ?>


### PR DESCRIPTION
Fixes #155

**This PR Addresses:**  
[@webdoc/default-template doesn't render example code](https://github.com/webdoc-labs/webdoc/issues/155)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>