### PR TITLE
Fix: Class Index not being rendered at the right location …

### DIFF
--- a/packages/webdoc-default-template/publish.js
+++ b/packages/webdoc-default-template/publish.js
@@ -444,7 +444,7 @@ async function outIndexes(
   function outIndex(indexKey, indexList /*: Array<Doc> */) {
     if (indexList.length > 0) {
       const title = KEY_TO_TITLE[indexKey];
-      const url = linker.processInternalURI(indexList.url, {outputRelative: true});
+      const url = linker.getFileSystemPath(indexList.url);
 
       pipeline.render("pages/api-index.tmpl", {
         appBar: {current: "reference"},

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -437,6 +437,12 @@ function LinkerPluginShell() {
       return this.processInternalURI(path.join("/<siteRoot>", subpath));
     }
 
+    getFileSystemPath(uri: string): string {
+      return this.siteRoot ?
+        uri.replace(this.siteRoot, "").replace("//", "/") :
+        uri;
+    }
+
     createURI(preferredUri: string, outputRelative?: boolean): string {
       const uri = this.generateBaseURI(preferredUri);
 


### PR DESCRIPTION


**This PR Addresses:**  
[Class-index.html issue when specifying a root folder](https://github.com/webdoc-labs/webdoc/issues/177)  


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>