### PR TITLE
Fix: Don't append to class signature if extends, implements arrays are empty

### DIFF
--- a/core/webdoc-default-template/helper/renderer-plugins/signature.js
+++ b/core/webdoc-default-template/helper/renderer-plugins/signature.js
@@ -68,13 +68,13 @@ exports.signaturePlugin = {
       }
       break;
     case "ClassDoc":
-      if (doc.extends) {
+      if (doc.extends && doc.extends.length > 0) {
         signature += ` extends ${
           (doc.extends || [])
             .map((superClass) => linker.linkTo(superClass, undefined, {htmlSafe: false})).join(", ")
         }`;
       }
-      if (doc.implements) {
+      if (doc.implements && doc.implements.length > 0) {
         signature += ` implements ${
           (doc.implements || [])
             .map((ifc) => linker.linkTo(ifc, undefined, {htmlSafe: false})).join(", ")


### PR DESCRIPTION
Fixes #188 