### PR TITLE
Add missing URL scheme

### DIFF
--- a/core/webdoc-default-template/tmpl/layout.tmpl
+++ b/core/webdoc-default-template/tmpl/layout.tmpl
@@ -33,7 +33,7 @@ const cssPageKind =
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Roboto+Mono&family=Source+Code+Pro&display=swap" />
-    <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
+    <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
     <?js Object.keys(config.meta).forEach((key) => { ?>
       <meta name="<?js= key ?>" content="<?js= config.meta[key].replace("{{url}}", `${config.siteDomain}`) ?>" />
     <?js }); ?>

--- a/core/webdoc-legacy-template/tmpl/layout.tmpl
+++ b/core/webdoc-legacy-template/tmpl/layout.tmpl
@@ -11,7 +11,7 @@
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/tomorrow.min.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
-    <link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
+    <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
 </head>
 <body>
     <div id="main">


### PR DESCRIPTION
The URL scheme is missing for `googlecode.min.css`:

```html
<link type="text/css" rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/googlecode.min.css">
```

It works fine on a real website, but if you open the output `.html` file locally, the browser will assume the scheme is `file:`, causing the error:

![image](https://user-images.githubusercontent.com/8724868/198843286-cb912121-7347-499a-ade7-da7a1c0624d5.png)

Adding an explicit `https:` solves the problem.
