### PR TITLE
Update version.number in defaultConfig

### DIFF
--- a/core/webdoc-cli/src/config.js
+++ b/core/webdoc-cli/src/config.js
@@ -71,7 +71,7 @@ type ConfigSchema = {
     variant: string,
   },
   version: {
-    number?: 1
+    number?: number,
   }
 };
 
@@ -133,7 +133,7 @@ const defaultConfig: ConfigSchema = {
     variant: "normal",
   },
   version: {
-    number: 1,
+    number: 2,
   },
 };
 /* eslint-enable no-multi-spaces */


### PR DESCRIPTION
Recently I found that the version number of Webdoc shown in the generated pages is wrong. For example, at the bottom of <https://pixijs.download/v7.1.2/docs/index.html>:

> Documentation generated by Webdoc 1

I dig deeper and found the `version.number` is still `1` in `defaultConfig`. This PR fixes this problem.